### PR TITLE
Require authentication again when first attempt failed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "selenium-webdriver": "^4.0.0-alpha.1",
     "sinon": "^5.0.7",
     "ts-node": "^6.0.3",
-    "tsc": "^1.20150623.0",
     "tslint": "^5.10.0",
     "tslint-eslint-rules": "^5.3.1",
     "typescript": "^2.8.3"


### PR DESCRIPTION
* Require authentication again when first attempt failed.

In firefox, upon bad authentication (with wrong credentials),
MesosTerm was then always returning a 401 error with a page containing the
message "Unauthorized". From this time on, ao authentication request was pushed
to the user anymore and therefore there was no way for him/her to fix the
credentials. The only workaround was to clear the browser cache.

* Remove bad tsc dependency.