### PR TITLE
Relax constraints on allowed_task_admins groups

### DIFF
--- a/scripts/tests/docker-compose.yml
+++ b/scripts/tests/docker-compose.yml
@@ -183,6 +183,35 @@ services:
       - MESOS_TERM_SESSION_SECRET=abcd
       - MESOS_TERM_SUPER_ADMINS=admins
 
+  mesos-term-allowed-admin:
+    build:
+      context: ../..
+    ports:
+      - "3003:3000"
+    networks:
+      mesos_command_modules_net:
+        ipv4_address: 172.16.130.11
+    links:
+      - mesos-master
+      - openldap
+    depends_on:
+      - mesos-master
+      - openldap
+    environment:
+      - MESOS_TERM_COMMAND=/bin/bash
+      - MESOS_TERM_ENABLE_PER_APP_ADMINS=true
+      - MESOS_TERM_ENABLE_RIGHTS_DELEGATION=true
+      - MESOS_TERM_LDAP_URL=ldap://openldap
+      - MESOS_TERM_LDAP_BASE_DN=dc=example,dc=com
+      - MESOS_TERM_LDAP_USER=cn=admin,dc=example,dc=com
+      - MESOS_TERM_LDAP_PASSWORD=password
+      - MESOS_TERM_JWT_SECRET=abcd
+      - MESOS_TERM_MESOS_MASTER_URL=http://mesos-master:5050
+      - MESOS_TERM_MESOS_STATE_CACHE_TIME=60
+      - MESOS_TERM_SESSION_SECRET=abcd
+      - MESOS_TERM_SUPER_ADMINS=admins
+      - MESOS_TERM_ALLOWED_TASK_ADMINS=devops
+
 networks:
   mesos_command_modules_net:
     driver: bridge

--- a/scripts/tests/docker-compose.yml
+++ b/scripts/tests/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "2181:2181"
     networks:
       mesos_command_modules_net:
-        ipv4_address: 172.16.121.2
+        ipv4_address: 172.16.130.2
 
   mesos-master:
     image: mesosphere/mesos-master:1.6.0-rc1
@@ -17,7 +17,7 @@ services:
       - "5050:5050"
     networks:
       mesos_command_modules_net:
-        ipv4_address: 172.16.121.3
+        ipv4_address: 172.16.130.3
     links:
       - zookeeper
     depends_on:
@@ -29,7 +29,7 @@ services:
       MESOS_HOSTNAME: localhost
       MESOS_WORK_DIR: /var/tmp/mesos
       MESOS_LOG_DIR: /var/log/mesos
-      LIBPROCESS_IP: 172.16.121.3
+      LIBPROCESS_IP: 172.16.130.3
 
   mesos-slave:
     build:
@@ -41,7 +41,7 @@ services:
       - "5051:5051"
     networks:
       mesos_command_modules_net:
-        ipv4_address: 172.16.121.4
+        ipv4_address: 172.16.130.4
     links:
       - zookeeper:zookeeper
       - mesos-master:master.mesos
@@ -60,7 +60,7 @@ services:
       MESOS_FRAMEWORKS_HOME: /var/tmp/mesos/frameworks
       MESOS_IMAGE_PROVIDERS: docker
       MESOS_ISOLATION: filesystem/linux,docker/runtime
-      LIBPROCESS_IP: 172.16.121.4
+      LIBPROCESS_IP: 172.16.130.4
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 
@@ -76,7 +76,7 @@ services:
      - "8080:8080"
     networks:
       mesos_command_modules_net:
-        ipv4_address: 172.16.121.5
+        ipv4_address: 172.16.130.5
     links:
       - zookeeper
       - mesos-master
@@ -87,7 +87,7 @@ services:
     environment:
       - MARATHON_ZK=zk://zookeeper:2181/marathon
       - MARATHON_MASTER=zk://zookeeper:2181/mesos
-      - LIBPROCESS_IP=172.16.121.5
+      - LIBPROCESS_IP=172.16.130.5
 
   openldap:
     image: clems4ever/openldap
@@ -95,7 +95,7 @@ services:
       - "389:389"
     networks:
       mesos_command_modules_net:
-        ipv4_address: 172.16.121.6
+        ipv4_address: 172.16.130.6
     environment:
       - SLAPD_ORGANISATION=MyCompany
       - SLAPD_DOMAIN=example.com
@@ -112,7 +112,7 @@ services:
       - "3000:3000"
     networks:
       mesos_command_modules_net:
-        ipv4_address: 172.16.121.8
+        ipv4_address: 172.16.130.8
     links:
       - mesos-master
       - openldap
@@ -140,7 +140,7 @@ services:
       - "3001:3000"
     networks:
       mesos_command_modules_net:
-        ipv4_address: 172.16.121.9
+        ipv4_address: 172.16.130.9
     links:
       - mesos-master
       - openldap
@@ -162,7 +162,7 @@ services:
       - "3002:3000"
     networks:
       mesos_command_modules_net:
-        ipv4_address: 172.16.121.10
+        ipv4_address: 172.16.130.10
     links:
       - mesos-master
       - openldap
@@ -219,4 +219,4 @@ networks:
       driver: default
       config:
       -
-        subnet: 172.16.121.0/24
+        subnet: 172.16.130.0/24

--- a/scripts/tests/ldap/base.ldif
+++ b/scripts/tests/ldap/base.ldif
@@ -32,6 +32,14 @@ mail: bob.dylan@authelia.com
 sn: Bob Dylan
 userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 
+dn: cn=alice,ou=users,dc=example,dc=com
+cn: alice
+objectclass: inetOrgPerson
+objectclass: top
+mail: alice@authelia.com
+sn: Alic Dylan
+userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
+
 dn: cn=james,ou=users,dc=example,dc=com
 cn: james
 objectclass: inetOrgPerson
@@ -52,12 +60,19 @@ dn: cn=dev,ou=groups,dc=example,dc=com
 cn: dev
 member: cn=bob,ou=users,dc=example,dc=com
 member: cn=james,ou=users,dc=example,dc=com
+member: cn=alice,ou=users,dc=example,dc=com
 objectclass: groupOfNames
 objectclass: top
 
 dn: cn=users,ou=groups,dc=example,dc=com
 cn: users
 member: cn=james,ou=users,dc=example,dc=com
+objectclass: groupOfNames
+objectclass: top
+
+dn: cn=devops,ou=groups,dc=example,dc=com
+cn: users
+member: cn=alice,ou=users,dc=example,dc=com
 objectclass: groupOfNames
 objectclass: top
 

--- a/scripts/tests/setup.sh
+++ b/scripts/tests/setup.sh
@@ -11,7 +11,7 @@ echo "Wait for LDAP to be ready"
 sleep 3
 
 # import users in LDAP
-docker run -it --network host -v $(pwd)/ldap/base.ldif:/base.ldif --rm mbentley/ldap-utils ldapadd -h 172.16.121.6 -D "cn=admin,dc=example,dc=com" -f /base.ldif -w password -x
+docker run -it --network host -v $(pwd)/ldap/base.ldif:/base.ldif --rm mbentley/ldap-utils ldapadd -h 172.16.130.6 -D "cn=admin,dc=example,dc=com" -f /base.ldif -w password -x
 
 echo "Wait for Marathon to be ready"
 sleep 15 # Wait for Marathon to start

--- a/src/authorizations.spec.ts
+++ b/src/authorizations.spec.ts
@@ -20,7 +20,7 @@ describe('authorizations', function() {
         const allowed_task_admins: string[] = [];
         const task_admins = ['foo'];
         expect(FilterTaskAdmins(task_admins_enabled, allowed_task_admins, task_admins))
-          .to.deep.equal(['foo']);
+          .to.deep.equal([['foo']]);
       });
     });
 
@@ -30,7 +30,7 @@ describe('authorizations', function() {
         const allowed_task_admins = ['foo'];
         const task_admins = ['foo'];
         expect(FilterTaskAdmins(task_admins_enabled, allowed_task_admins, task_admins))
-          .to.deep.equal(['foo']);
+          .to.deep.equal([['foo'], ['foo']]);
       });
     });
     describe('all admins are authorized', function() {

--- a/src/authorizations.ts
+++ b/src/authorizations.ts
@@ -26,33 +26,48 @@ function extractCN(groups: string[]): string[] {
 }
 
 // TODO: integrate all public methods in one authorizer class
+// returns a list of of list of groups
+// users must be in at least one group of each entry to be allowed to admin of a container
 export function FilterTaskAdmins(
-  task_admins_enabled: boolean,
-  allowed_task_admins: string[],
-  task_admins: string[]): string[] {
+  task_admins_enabled: boolean, // ENABLE_PER_APP_ADMINS
+  allowed_task_admins: string[], // ALLOWED_TASK_ADMINS
+  task_admins: string[]): string[][] { // DEBUG_GRANTED_TO
   if (!task_admins_enabled) {
     return [];
   }
 
   if (allowed_task_admins.length == 0) {
-    return task_admins;
+    return [task_admins];
   }
 
-  return intersection(allowed_task_admins, task_admins);
+  return [allowed_task_admins, task_admins];
 }
 
 export function CheckUserAuthorizations(
   userCN: string,
   userLdapGroups: string[],
-  admins: string[],
+  admins_constraints: string[][],
   superAdmins: string[]) {
 
   const userGroups = extractCN(userLdapGroups);
   const userAndGroups = [userCN].concat(userGroups);
-  const allowed = admins.concat(superAdmins);
-  return (intersection(userAndGroups, allowed).length > 0)
+  const isUserSuperAdmin = (intersection(userAndGroups, superAdmins).length > 0);
+
+  if (isUserSuperAdmin) {
+    return Bluebird.resolve();
+  }
+
+  if (admins_constraints.length == 0) {
+    return Bluebird.reject(new Error('Unauthorized access to container. Only super admins can connect to this container.'));
+  }
+
+  return admins_constraints.every(matches, userAndGroups)
     ? Bluebird.resolve()
     : Bluebird.reject(new Error('Unauthorized access to container.'));
+}
+
+function matches(element: string[], index: number, array: string[][]) {
+  return intersection(element, this).length > 0;
 }
 
 export function CheckRootContainer(

--- a/src/controllers/terminal.ts
+++ b/src/controllers/terminal.ts
@@ -136,7 +136,7 @@ function checkAuthorizations(
 
   const userCN = req.user.cn;
   const userLdapGroups = req.user.memberOf;
-  const admins = Authorizations.FilterTaskAdmins(
+  const admins_constraints = Authorizations.FilterTaskAdmins(
     env.ENABLE_PER_APP_ADMINS,
     env.ALLOWED_TASK_ADMINS,
     task.admins);
@@ -147,7 +147,7 @@ function checkAuthorizations(
       Authorizations.CheckUserAuthorizations(
         userCN,
         userLdapGroups,
-        admins,
+        admins_constraints,
         superAdmins
       ),
       Authorizations.CheckRootContainer(

--- a/tests/app6.ts
+++ b/tests/app6.ts
@@ -21,8 +21,34 @@ describe('app6 (label GRANTED_TO dev and harry, no root)', function() {
         AppsHelpers.testInteractionsWithTerminal(3000, 'bob', 'app6');
       });
 
+      describe('user alice (in devOPS & dev groups)', function() {
+        AppsHelpers.testInteractionsWithTerminal(3000, 'alice', 'app6');
+      });
+
       describe('user blackhat', function() {
         AppsHelpers.testUnauthorizedUser(3000, 'blackhat', 'app6');
+      });
+    });
+
+    describe('admins are whitelisted', function()  {
+      describe('super admin user', function() {
+        AppsHelpers.testInteractionsWithTerminal(3003, 'john', 'app6');
+      });
+
+      describe('user harry', function() {
+        AppsHelpers.testUnauthorizedUser(3003, 'blackhat', 'app6');
+      });
+
+      describe('user bob (in dev group)', function() {
+        AppsHelpers.testUnauthorizedUser(3003, 'blackhat', 'app6');
+      });
+
+      describe('user alice (in devOPS group)', function() {
+        AppsHelpers.testInteractionsWithTerminal(3003, 'alice', 'app6');
+      });
+
+      describe('user blackhat', function() {
+        AppsHelpers.testUnauthorizedUser(3003, 'blackhat', 'app6');
       });
     });
 
@@ -37,6 +63,10 @@ describe('app6 (label GRANTED_TO dev and harry, no root)', function() {
 
       describe('user bob (in dev group)', function() {
         AppsHelpers.testUnauthorizedUser(3002, 'bob', 'app6');
+      });
+
+      describe('user alice (in dev group)', function() {
+        AppsHelpers.testUnauthorizedUser(3002, 'alice', 'app6');
       });
 
       describe('user blackhat', function() {


### PR DESCRIPTION

Relax constraints on allowed_task_admins groups

Before this patch, permissions allowed following scheme:

- members of MESOS_TERM_SUPER_ADMINS groups can connect on every container
- members of MESOS_TERM_ALLOWED_TASK_ADMINS groups can connect on containers if MESOS_TERM_DEBUG_GRANTED_TO contains exactly the same group

This patch changes it to:

- members of MESOS_TERM_SUPER_ADMINS groups can connect on every container (no change)
- members of MESOS_TERM_ALLOWED_TASK_ADMINS groups can connect on containers if they belong to a group listed by MESOS_TERM_DEBUG_GRANTED_TO

The difference is that we could configure a large group of users to connect to their container only (let's say a group called "operators") without listing every group that should be whitelisted in MESOS_TERM_ALLOWED_TASK_ADMINS or activating MESOS_TERM_ENABLE_PER_APP_ADMINS (which would give everyone access to their container)

Fixes #14 