### PR TITLE
Always consider lower case groups

### DIFF
--- a/src/authorizations.spec.ts
+++ b/src/authorizations.spec.ts
@@ -1,7 +1,44 @@
 import { expect } from 'chai';
 import { FilterTaskAdmins } from './authorizations';
+import { CheckUserAuthorizations } from './authorizations';
 
 describe('authorizations', function() {
+
+  describe('CheckUserAuthorizations', function() {
+    describe('when groups are matching', function() {
+      it('should authorize', function(done) {
+        const userCN = 'foo';
+        const userLdapGroups = ['CN=bar', 'CN=agroup'];
+        const admins_constraints = [['bar'], ['agroup']];
+        const superAdmins = ['superadmingroup'];
+
+        const promise = CheckUserAuthorizations(userCN, userLdapGroups, admins_constraints, superAdmins);
+        promise.then(() => done(), done);
+      });
+    });
+    describe('when groups are not matching', function() {
+      it('should authorize', function(done) {
+        const userCN = 'foo';
+        const userLdapGroups = ['CN=bar'];
+        const admins_constraints = [['bar'], ['agroup']];
+        const superAdmins = ['superadmingroup'];
+
+        const promise = CheckUserAuthorizations(userCN, userLdapGroups, admins_constraints, superAdmins);
+        promise.then(() => done('Should not authorize'), (err) => done());
+      });
+    });
+    describe('when capitalization is different', function() {
+      it('should authorize anyway', function(done) {
+        const userCN = 'foo';
+        const userLdapGroups = ['CN=bar', 'CN=aGroupWithCap'];
+        const admins_constraints = [['bar'], ['agroupwithcap']];
+        const superAdmins = ['superadmingroup'];
+
+        const promise = CheckUserAuthorizations(userCN, userLdapGroups, admins_constraints, superAdmins);
+        promise.then(() => done(), done);
+      });
+    });
+  });
 
   describe('FilterTaskAdmins', function() {
     describe('per app admins is disabled', function() {

--- a/src/authorizations.ts
+++ b/src/authorizations.ts
@@ -22,7 +22,7 @@ function extractCN(groups: string[]): string[] {
   return groups.map((m: string) => {
     const matches = m.match(/^(CN|cn)=([a-zA-Z0-9_-]+)/m);
     return (matches.length > 1) ? matches[2] : undefined;
-  }).filter(m => m !== undefined);
+  }).filter(m => m !== undefined).map(m => m.toLowerCase());
 }
 
 // TODO: integrate all public methods in one authorizer class
@@ -47,7 +47,7 @@ export function CheckUserAuthorizations(
   userCN: string,
   userLdapGroups: string[],
   admins_constraints: string[][],
-  superAdmins: string[]) {
+  superAdmins: string[]): Bluebird<void> {
 
   const userGroups = extractCN(userLdapGroups);
   const userAndGroups = [userCN].concat(userGroups);


### PR DESCRIPTION
On ldap that are AD it is not unusual to see mixed capitalization on
groups. This patch forces every group to be lower cased

Change-Id: I40fcb541a9126bdf1f26d13452d1d360ef7807a1