### PR TITLE
Add ability to run mesos-term in task groups

### DIFF
--- a/scripts/tests/create_apps.sh
+++ b/scripts/tests/create_apps.sh
@@ -8,3 +8,4 @@ $script_dir/mesos/create_app.sh $script_dir/mesos/apps/app3.json
 $script_dir/mesos/create_app.sh $script_dir/mesos/apps/app4.json
 $script_dir/mesos/create_app.sh $script_dir/mesos/apps/app5.json
 $script_dir/mesos/create_app.sh $script_dir/mesos/apps/app6.json
+$script_dir/mesos/create_pod.sh $script_dir/mesos/apps/pod1.json

--- a/scripts/tests/mesos/apps/pod1.json
+++ b/scripts/tests/mesos/apps/pod1.json
@@ -1,0 +1,12 @@
+{
+   "id": "/pod1",
+   "scaling": { "kind": "fixed", "instances": 1 },
+   "containers": [
+     {
+       "name": "pod1",
+       "exec": { "command": { "shell": "env & sleep 3600" } },
+       "resources": { "cpus": 0.1, "mem": 16 }
+     }
+   ],
+   "networks": [ {"mode": "host"} ]
+}

--- a/scripts/tests/mesos/create_pod.sh
+++ b/scripts/tests/mesos/create_pod.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+curl -XPOST -H 'Content-Type: application/json' -H 'Accept: application/json' -d @$1 http://localhost:8080/v2/pods/

--- a/src/controllers/terminal.ts
+++ b/src/controllers/terminal.ts
@@ -106,6 +106,11 @@ function spawnTerminal(
     params.push(task.user);
   }
 
+  if (task.parent_container_id) {
+    params.push('--parent');
+    params.push(task.parent_container_id);
+  }
+
   if (env.EXTRA_ENV) {
     params.push('--env');
     params.push(env.EXTRA_ENV);

--- a/src/mesos.ts
+++ b/src/mesos.ts
@@ -16,6 +16,9 @@ interface MesosStatus {
   container_status: {
     container_id: {
       value: string;
+      parent: {
+        value: string;
+      }
     }
   };
 }
@@ -56,6 +59,7 @@ export interface Task {
   labels: Labels;
   user: string;
   container_id: string;
+  parent_container_id: string;
   slave_id: string;
   framework_id: string;
   agent_url: string;
@@ -135,6 +139,11 @@ export function getTaskInfo(mesos_master_url: string, taskId: string): Bluebird<
       }
 
       const containerId = statuses[0].container_status.container_id.value;
+      // Nested containers for task groups
+      let parentContainerId: string;
+      if (statuses[0].container_status.container_id.parent) {
+        parentContainerId = statuses[0].container_status.container_id.parent.value;
+      }
       const labels = fromMesosLabels(taskInfo.labels);
 
       const slaves = mesosState.slaves
@@ -158,6 +167,7 @@ export function getTaskInfo(mesos_master_url: string, taskId: string): Bluebird<
         labels: labels,
         user: taskInfo.user,
         container_id: containerId,
+        parent_container_id: parentContainerId,
         slave_id: taskInfo.slave_id,
         framework_id: taskInfo.framework_id,
         agent_url: slave_url,

--- a/tests/apps_helpers.ts
+++ b/tests/apps_helpers.ts
@@ -8,7 +8,7 @@ const TIMEOUT = 10000;
 export function interactWithTerminal(driver: any) {
   return driver.wait(webdriver.until.elementLocated(webdriver.By.css(".xterm-rows")), TIMEOUT)
     .then(function(el: webdriver.WebElement) {
-      return Bluebird.resolve(driver.wait(webdriver.until.elementTextContains(el, 'runs'), TIMEOUT));
+      return Bluebird.resolve(driver.wait(webdriver.until.elementTextMatches(el, /\$|#/), TIMEOUT));
     })
     .then(function() {
       return Bluebird.resolve(

--- a/tests/pod1.ts
+++ b/tests/pod1.ts
@@ -1,0 +1,10 @@
+import AppsHelpers = require('./apps_helpers');
+import Helpers = require('./helpers');
+
+describe('pod1 (no label, no root)', function() {
+  describe('authorizations disabled', function() {
+    describe('user john', function() {
+      AppsHelpers.testInteractionsWithTerminal(3001, 'john', 'pod1');
+    });
+  });
+});


### PR DESCRIPTION
When using Mesos task groups, tasks are actually running as nested
containers already. This means that to identify a container we need both
its containerId and the parent containerId.