### PR TITLE
Allow tests to be launched from docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,6 @@ node_js:
 services:
   - docker
   - ntp
-addons:
-  chrome: stable 
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - libgif-dev
-      - google-chrome-stable
-
-before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  - sleep 3
 
 script:
   - ./scripts/build.sh

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,14 @@
+This document describes how to test mesos-term.
+
+Integration testing
+===================
+
+```
+cd scripts/tests/
+docker-compose up -d
+cd ../..
+docker build -t mesos-term/ci  scripts/tests/
+docker run -v $(pwd):/in_and_out --network=host  -ti mesos-term/ci  /bin/bash
+```
+
+And then type: `xvfb-run npm run test-int`

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -12,7 +12,9 @@ pushd $script_dir/tests
 set +x
 set +e
 
-npm run test-int
+docker build -t mesos-term/ci .
+pushd ../..
+docker run -v $(pwd):/in_and_out --network=host  mesos-term/ci && popd
 
 if [ "$?" -ne "0" ];
 then

--- a/scripts/tests/Dockerfile
+++ b/scripts/tests/Dockerfile
@@ -1,0 +1,12 @@
+FROM owncloudci/nodejs:11.x
+
+COPY google-chrome.list /etc/apt/sources.list.d/google-chrome.list
+
+RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN apt-get update
+RUN apt-get -y install libgif-dev google-chrome-stable xvfb
+
+ENV MESOS_MASTER_URL=http://172.16.130.3:5050
+
+WORKDIR /in_and_out
+CMD ["xvfb-run" , "npm", "run", "test-int"]

--- a/scripts/tests/google-chrome.list
+++ b/scripts/tests/google-chrome.list
@@ -1,0 +1,1 @@
+deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main

--- a/tests/00-init.ts
+++ b/tests/00-init.ts
@@ -2,11 +2,11 @@ import Request = require('request-promise');
 import BluebirdPromise = require('bluebird');
 
 function getMesosState() {
-  return Request({ uri: 'http://localhost:5050/master/state.json', json: true });
+  return Request({ uri: process.env['MESOS_MASTER_URL'] + '/master/state.json', json: true });
 }
 
 function getMesosTasks() {
-  return Request({ uri: 'http://localhost:5050/master/tasks.json', json: true });
+  return Request({ uri: process.env['MESOS_MASTER_URL'] + '/master/tasks.json', json: true });
 }
 
 before(function() {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,16 +1,21 @@
 require('chromedriver');
 import webdriver = require('selenium-webdriver');
+import chrome = require('selenium-webdriver/chrome');
 import Bluebird = require('bluebird');
 import Request = require('request-promise');
 
 export function withChrome<T>(
   fn: (driver: webdriver.WebDriver) => Bluebird<T>): Bluebird<T> {
 
-  let pref = new webdriver.logging.Preferences();
+  const pref = new webdriver.logging.Preferences();
   pref.setLevel('browser', webdriver.logging.Level.SEVERE);
+
+  const options = new chrome.Options();
+  options.addArguments('--headless', '--no-sandbox');
 
   const driver = new webdriver.Builder()
     .forBrowser('chrome')
+    .setChromeOptions(options)
     .setLoggingPrefs(pref)
     .build();
 


### PR DESCRIPTION
Having a working setup of nodejs on my machine is painful, especially
considering that tests must run with nodejs 11 (I don't know exactly
why).
This patch makes it possible for a developer to run tests from a
container

A future patch could modify the way travis runs tests to use this
container.