### PR TITLE
Detect EOF in FileReader when container dies.

### DIFF
--- a/web/src/hooks/FileReader.ts
+++ b/web/src/hooks/FileReader.ts
@@ -24,6 +24,7 @@ export function useFileReader(
     const [init, setInit] = useState(false);
     const [displayedLines, setDisplayedLines] = useState([] as string[]);
     const lineRange = buffer.current ? buffer.current.lineRange : { start: 0, end: 0 };
+    const [eof, setEof] = useState(false);
 
     const readPreviousPortion = useCallback(async () => {
         if (!buffer.current) {
@@ -58,6 +59,9 @@ export function useFileReader(
             buffer.current.lineRange.end += newContentLines.length - contentLines.length;
             setDisplayedLines(newContentLines);
         }
+        if (res.eof) {
+            setEof(true);
+        }
     }, [setDisplayedLines, taskID, chunkSize, path]);
 
     const initialize = useCallback(async () => {
@@ -80,13 +84,15 @@ export function useFileReader(
     }, [taskID, path, readPreviousPortion]);
 
     useEffect(() => {
-        timer.current = setInterval(readNextPortion, 2000);
+        if (!eof) {
+            timer.current = setInterval(readNextPortion, 2000);
+        }
         return () => {
             if (timer.current) {
                 clearInterval(timer.current);
             }
         }
-    }, [readNextPortion]);
+    }, [readNextPortion, eof]);
 
     useEffect(() => {
         if (contentRef.current && follow) {

--- a/web/src/services/MesosTerm.ts
+++ b/web/src/services/MesosTerm.ts
@@ -124,6 +124,7 @@ export async function browseSandbox(taskID: string, path: string) {
 export interface FileData {
     data: string;
     offset: number;
+    eof: boolean;
 }
 
 export async function readSandboxFile(taskID: string, path: string, offset: number, size: number) {


### PR DESCRIPTION
Previously, the file reader was checking for new available data even
when the container was dead.

This lead to a side effect when the task disappeared from the mesos
state. Indeed, if the browser was open for long enough, the file reader
was still checking every 2s if new data was available even when the
container was dead and until the container disappears from the mesos
state. When the container disappeared from mesos state, some side
effects unveiled.

Since the regular check (2s) was querying the mesos state cache to find
the slave where the task was running and since the task disappeared
from mesos state cache, a cache invalidation was always triggered every
2s.
This is explained by the fact that the mesos state cache is invalidated
when a query for a task id is done and the task does not exist in cache
yet. This feature allows to refresh the cache before the next regular
refresh to improve the user experience. It allows to not show an error
message when the container has just spawned.

The fix in this PR detects when the task is dead and forwards that
information to the file reader which can then stop listening for new
updates.
Please note that the container status information has the same
refresh rate as the mesos state cache. So even when the container dies
the file reader will keep checking new updates until next mesos state
refresh.