### PR TITLE
Debuggability: Always return error to the user

### DIFF
--- a/src/controllers/sandbox.ts
+++ b/src/controllers/sandbox.ts
@@ -150,8 +150,10 @@ export default function (app: Express.Application) {
                 res.send('Task not found');
                 return;
             }
-            res.status(503);
-            res.send();
+            // returning 400 allow to display response body to the user
+            // if using 503 we simply return "503 != 200" message
+            res.status(400);
+            res.send(err.message);
             return;
         }
     });

--- a/src/controllers/terminal.ts
+++ b/src/controllers/terminal.ts
@@ -202,8 +202,10 @@ async function createTerminal(
       res.send('Mesos agent not found');
       return;
     }
-    res.status(503);
-    res.send();
+    // returning 400 allow to display response body to the user
+    // if using 503 we simply return "503 != 200" message
+    res.status(400);
+    res.send(err.message);
   }
 }
 

--- a/src/mesos.ts
+++ b/src/mesos.ts
@@ -190,6 +190,7 @@ function taskToTaskInfo(task: MesosTask, state: MesosState): TaskInfo {
   }
 
   if (runningStatuses.length > 1) {
+    console.log(task); // log full task detail to allow further investigation
     throw new Error(`Multiple running statuses has been found for the task ${task.id}`);
   }
 


### PR DESCRIPTION
This improves debuggability since users are able to report the real
error to mesos-term operators.

Downside: some exceptions might reveal errors we prefer to hide.
However, it does not show stacktrace, only a message.

Example: 
![image](https://user-images.githubusercontent.com/503537/81046729-4bcc5e00-8eb9-11ea-869f-822d27350941.png)
