### PR TITLE
Allow to use sandbox for tasks that never ran

### DIFF
--- a/src/controllers/sandbox.ts
+++ b/src/controllers/sandbox.ts
@@ -83,7 +83,7 @@ const sandboxCache = cacheSandboxDescriptor(async (taskID) => {
         workDir: slaveState.flags.work_dir,
         slaveID: slaveState.id,
         frameworkID: taskInfo.framework_id,
-        containerID: taskInfo.container_id,
+        containerID: slaveTaskInfos[0].container,
         task: taskInfo,
         last_status: status,
     };


### PR DESCRIPTION
Before this patch, tasks that never ran (for instance a task that failed
to download its artifacts) could not be explored using sandbox page.

This was due to the fact that mesos master state had no running status
and we rely on this status to extract various container ids (necessary
to request sandbox content and launch session within container).

In the case of task that never ran, we can use the slave state to
extract the container id which is the only necessary information to
explore sandbox. We can't find the parent container id but don't need it
since it is required to launch a session only.

This patch pushed me to extend the MesosTask interface with container
info.

Change-Id: I67e57c6928d9b36107d733d24a628813e82ed251
JIRA: MESOS-4060